### PR TITLE
some fixes to SCLOrkClock

### DIFF
--- a/classes/SCLOrkClock.sc
+++ b/classes/SCLOrkClock.sc
@@ -83,6 +83,7 @@ SCLOrkClock {
 			wire.onConnected = { | wire, status |
 				switch (status,
 					\connected, {
+						"*** connected to clock server.".postln;
 						// Request curent list of all clocks.
 						wire.sendMsg('/clockGetAll');
 					},

--- a/classes/SCLOrkClock.sc
+++ b/classes/SCLOrkClock.sc
@@ -311,9 +311,10 @@ SCLOrkClock {
 	}
 
 	tempo_ { | newTempo |
-		if (currentState.tempo != newTempo, {
-			var nextBeat = this.beats.roundUp;
-			this.setTempoAtBeat(newTempo, nextBeat);
+		var floatTempo = newTempo.asFloat;
+		if (currentState.tempo != floatTempo, {
+			var nextBeat = this.beats.roundUp.asFloat;
+			this.setTempoAtBeat(floatTempo, nextBeat);
 		});
 	}
 
@@ -368,7 +369,7 @@ SCLOrkClock {
 	timeToNextBeat { | qunat = 1.0 |
 	}
 
-	nextTimeOnGrid { | quant = 1.0, phase = 0 |
+	nextTimeOnGrid { | quant = 1.0, phase = 0.0 |
 		if (quant == 0.0, { ^(this.beats + phase); });
 		if (quant < 0.0, { quant = currentState.beatsPerBar * quant.neq });
 		if (phase < 0.0, { phase = phase % quant });

--- a/classes/SCLOrkClock.sc
+++ b/classes/SCLOrkClock.sc
@@ -1,4 +1,4 @@
-SCLOrkClock {
+SCLOrkClock : Clock {
 	const historySize = 60;
 	const <syncPort = 4249;
 
@@ -227,27 +227,34 @@ SCLOrkClock {
 	prAdvance {
 		var sec = Main.elapsedTime;
 		var beat = this.beats;
-		var topBeat;
+		var threadClock, topBeat, next;
 		while ({
 			topBeat = queue.topPriority;
 			topBeat.notNil and: { topBeat <= beat }}, {
 			var task = queue.pop;
-			// Little bit of fudging going on here where we are sending
-			// the scheduled beat count instead of the actual current
-			// beat timing. Some beats can be a bit off due to clock drift
-			// updates from the server.
-			var repeat = task.awake(topBeat, sec, this);
-			if (repeat.isNumber, {
-				queue.put(topBeat + repeat, task);
-			});
+			try {
+				var repeat;
+				threadClock = thisThread.clock;
+				thisThread.clock = this;
+				// Little bit of fudging going on here where we are sending
+				// the scheduled beat count instead of the actual current
+				// beat timing. Some beats can be a bit off due to clock drift
+				// updates from the server.
+				repeat = task.awake(topBeat, sec, this);
+				thisThread.clock = threadClock;
+				if (repeat.isNumber, {
+					queue.put(topBeat + repeat, task);
+				});
+			} {
+				"*** clock scheduling exception".postln;
+			}
 		});
 
 		if (topBeat.notNil, {
-			var next = max(this.beats2secs(topBeat) - sec, 0.05);
-			^next;
-		}, {
-			^nil;
+			next = max(this.beats2secs(topBeat) - sec, 0.05);
 		});
+
+		^next;
 	}
 
 	// Coupla key differences - using the stateQueue, always
@@ -322,7 +329,7 @@ SCLOrkClock {
 		^currentState.secs2beats(Main.elapsedTime, timeDiff);
 	}
 
-	schedAbs { | beats, item |
+	schedAbs { |beats, item|
 		queue.put(beats, item);
 		this.prScheduleTop;
 	}
@@ -331,7 +338,8 @@ SCLOrkClock {
 		this.schedAbs(this.beats + delta, item);
 	}
 
-	play { | task, quant = 1 |
+	play { |task, quant = 1|
+		"*** play called".postln;
 		this.schedAbs(quant.nextTimeOnGrid(this), task);
 	}
 
@@ -354,22 +362,28 @@ SCLOrkClock {
 		^currentState.beats2bars(this.beats);
 	}
 
-	nextBar { | beat |
+	nextBar { |beat|
+		if (beat.isNil, { beat = this.beats });
+		^this.bars2beats(this.beats2bars(beat).ceil);
 	}
 
 	beatInBar {
+		^this.beats - this.bars2beats(this.bar);
 	}
 
-	beats2bars { | beats |
+	beats2bars { |beats|
+		^currentState.beats2bars(beats);
 	}
 
-	bars2beats { | bars |
+	bars2beats { |bars|
+		^currentState.bars2beats(bars);
 	}
 
-	timeToNextBeat { | qunat = 1.0 |
+	timeToNextBeat { |quant = 1.0|
+		^quant.nextTimeOnGrid(this) - this.beats;
 	}
 
-	nextTimeOnGrid { | quant = 1.0, phase = 0.0 |
+	nextTimeOnGrid { |quant = 1.0, phase = 0.0|
 		if (quant == 0.0, { ^(this.beats + phase); });
 		if (quant < 0.0, { quant = currentState.beatsPerBar * quant.neq });
 		if (phase < 0.0, { phase = phase % quant });
@@ -378,6 +392,7 @@ SCLOrkClock {
 	}
 
 	elapsedBeats {
+		this.secs2beats(Main.elapsedTime);
 	}
 
 	seconds {

--- a/classes/SCLOrkClock.sc
+++ b/classes/SCLOrkClock.sc
@@ -339,7 +339,6 @@ SCLOrkClock : Clock {
 	}
 
 	play { |task, quant = 1|
-		"*** play called".postln;
 		this.schedAbs(quant.nextTimeOnGrid(this), task);
 	}
 

--- a/classes/SCLOrkClockState.sc
+++ b/classes/SCLOrkClockState.sc
@@ -72,19 +72,27 @@ SCLOrkClockState {
 	setTempoAtBeat { | newTempo, beats |
 		var state = SCLOrkClockState.new(
 			cohortName: cohortName,
-			applyAtBeat: beats,
+			applyAtBeat: beats.asFloat,
 			// Local clocks will compute and attach a server time to their copy
 			// of this state, so it will set to a valid value when becoming current.
 			applyAtTime: 0.0,
-			tempo: newTempo,
-			beatsPerBar: beatsPerBar,
-			baseBar: baseBar,
-			baseBarBeat: baseBarBeat);
+			tempo: newTempo.asFloat,
+			beatsPerBar: beatsPerBar.asFloat,
+			baseBar: baseBar.asFloat,
+			baseBarBeat: baseBarBeat.asFloat);
 		^state;
 	}
 
 	toMessage {
 		var msg = Array.newClear(14);
+		// Sanitize numbers to floats before serializing.
+		applyAtBeat = applyAtBeat.asFloat;
+		applyAtTime = applyAtTime.asFloat;
+		tempo = tempo.asFloat;
+		beatsPerBar = beatsPerBar.asFloat;
+		baseBar = baseBar.asFloat;
+		baseBarBeat = baseBarBeat.asFloat;
+
 		msg[0] = nil;   // Leave blank for sender to populate
 		msg[1] = cohortName;
 		msg[2] = applyAtBeat.high32Bits;


### PR DESCRIPTION
Now works with Pbindef and other Pattern siblings. This required support for scheduling methods with a ^ as the return, supported with a try block in the method invocation. Also some fixes to allow integer arguments to be converted to floats before serializing.