### PR TITLE
revise default SCLOrkChat port to 61010

### DIFF
--- a/classes/SCLOrkChatClient.sc
+++ b/classes/SCLOrkChatClient.sc
@@ -22,7 +22,7 @@ SCLOrkChatClient {
 	var <>onMessageReceived;  // called with chatMessage object on receipt
 	var <>onUserChanged;  // called with user changes, type, userid, nickname.
 
-	*new { |serverAddress = "cmn17.stanford.edu", serverPort = 61000|
+	*new { |serverAddress = "cmn17.stanford.edu", serverPort = 61010|
 		^super.newCopyArgs(serverAddress, serverPort).init;
 	}
 

--- a/scide_scqt/SCLOrkChat.sc
+++ b/scide_scqt/SCLOrkChat.sc
@@ -51,7 +51,7 @@ SCLOrkChat {
 			name = "noname";
 		});
 		if (chatClient.isNil, {
-			chatClient = SCLOrkChatClient.new("cmn17.stanford.edu", 61000);
+			chatClient = SCLOrkChatClient.new("cmn17.stanford.edu", 61010);
 		});
 		quitTasks = false;
 		wedged = false;

--- a/src/confab/confab-server.cpp
+++ b/src/confab/confab-server.cpp
@@ -13,7 +13,7 @@
 #include <unistd.h>
 
 // Command line flags for the HTTP server.
-DEFINE_int32(chatPort, 61000, "OSC TCP port for incoming chat messgaes");
+DEFINE_int32(chatPort, 61010, "OSC TCP port for incoming chat messgaes");
 
 int main(int argc, char* argv[]) {
     gflags::ParseCommandLineFlags(&argc, &argv, true);


### PR DESCRIPTION
It seems that jacktrip is using 61000, probably only for UDP, but to be safe we move SCLOrkChat server and clients to default to 61010.