### PR TITLE
suppress private messages locally

### DIFF
--- a/classes/SCLOrkChatClient.sc
+++ b/classes/SCLOrkChatClient.sc
@@ -106,20 +106,23 @@ SCLOrkChatClient {
 		chatReceiveFunc = OSCFunc.new({ |msg|
 			var serial = msg[1];
 			if (serial > messageSerial, {
-				var chatMessage = SCLOrkChatMessage.new(
-					msg[2],
-					msg[5..],
-					msg[3],
-					msg[4],
-					nameMap.at(msg[2]),
-					msg[2] == userId);
-				messageSerial = serial;
-				// Populate list of recipient names if it is not a broadcast.
-				if (chatMessage.recipientIds[0] != 0, {
-					chatMessage.recipientNames = nameMap.atAll(
-						chatMessage.recipientIds);
+				var recipients = msg[5..];
+				if (recipients[0] == 0 or: { recipients.indexOf(userId).notNil }, {
+					var chatMessage = SCLOrkChatMessage.new(
+						msg[2],
+						recipients,
+						msg[3],
+						msg[4],
+						nameMap.at(msg[2]),
+						msg[2] == userId);
+					messageSerial = serial;
+					// Populate list of recipient names if it is not a broadcast.
+					if (chatMessage.recipientIds[0] != 0, {
+						chatMessage.recipientNames = nameMap.atAll(
+							chatMessage.recipientIds);
+					});
+					onMessageReceived.(chatMessage);
 				});
-				onMessageReceived.(chatMessage);
 			});
 		},
 		path: '/chatReceive',


### PR DESCRIPTION
Fixes #32. With the redesign of SCLOrkChat server to use OSC over TCP, the server no longer pushes messages but rather responds to requests for messages at a high polling rate. To distribute the workload from the server we move private message filtration to the client, and only relay messages from the chat client to consumers when they are broadcast messages or the client has a matching userId.